### PR TITLE
Release/1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.2
+=============
+* Fixed:
+  * magento 2 fails to read the _extend.scss and the _module.scss from modules
+  
 1.0.1
 =============
 * Fixed:

--- a/PreProcessor/Instruction/Import.php
+++ b/PreProcessor/Instruction/Import.php
@@ -67,7 +67,7 @@ class Import extends BaseClass
         try{
             $temp->getContent();
         }catch(\Exception $e){
-            $matchedFileId = preg_replace('/(.+\/)?(.+)/', '$1_$2',$matchedFileId);
+            $matchedFileId = preg_replace('/(.+\/)?_?(.+)/', '$1_$2',$matchedFileId);
             $resolvedPath = $this->notationResolver->convertModuleNotationToPath($asset, $matchedFileId);
         }
 


### PR DESCRIPTION
1.0.2
=============
* Fixed:
  * magento 2 fails to read the _extend.scss and the _module.scss from modules